### PR TITLE
feat(android): nativeAds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
 	implementation 'com.google.android.ads.consent:consent-library:1.0.8'
-	implementation 'com.facebook.android:audience-network-sdk:5.6.1'
-	implementation 'com.google.ads.mediation:facebook:5.6.1.0'
-	implementation 'com.google.android.gms:play-services-base:17.1.0'
-	implementation 'com.google.android.gms:play-services-ads:18.3.0'
-	implementation 'com.google.android.gms:play-services-ads-base:18.3.0'
-	implementation 'com.google.android.gms:play-services-ads-identifier:17.0.0'
-	implementation 'com.google.android.gms:play-services-ads-lite:18.3.0'
+	implementation 'com.facebook.android:audience-network-sdk:6.13.7'
+	implementation 'com.google.ads.mediation:facebook:6.13.7.0'
+	implementation 'com.google.android.gms:play-services-base:18.2.0'
+	implementation 'com.google.android.gms:play-services-ads:22.0.0'
+	implementation 'com.google.android.gms:play-services-ads-base:22.0.0'
+	implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
+	implementation 'com.google.android.gms:play-services-ads-lite:22.0.0'
 }

--- a/android/documentation/index.md
+++ b/android/documentation/index.md
@@ -4,19 +4,19 @@
 
 Allows for the display of AdMob in Titanium Android applications.
 
-Please note that if your androidManifest has screen support set to: android:anyDensity="false", any banner ads will 
+Please note that if your androidManifest has screen support set to: android:anyDensity="false", any banner ads will
 display too small on high density devices.
 It is not clear at this point if this is a bug with AdMob or Titanium.
 In any event, you will either need to NOT set your screen support -- or set android:anyDensity="true" and adjust your app layout accordingly
 
 ## Getting Started
 
-View the [Using Titanium Modules](http://docs.appcelerator.com/platform/latest/#!/guide/Using_Titanium_Modules) document 
+View the [Using Titanium Modules](http://docs.appcelerator.com/platform/latest/#!/guide/Using_Titanium_Modules) document
 for instructions on getting started with using this module in your application.
 
 In order to use the module you would need to add the following tags in yout tiapp.xml
 
-	<android 
+	<android
 	    xmlns:android="http://schemas.android.com/apk/res/android">
 	    <manifest>
 	      <application>
@@ -51,13 +51,6 @@ The "Admob" variable is now a reference to the Module object.
 ### initialize(admobApplicationID)
 
 You need to initialize the Admob SDK by passing your AdmobAppID as a parameter to this method.
-
-### Number isGooglePlayServicesAvailable()
-
-Returns a number value indicating the availability of Google Play Services which are for push notifications.
-
-Possible values include `SUCCESS`, `SERVICE_MISSING`, `SERVICE_VERSION_UPDATE_REQUIRED`, `SERVICE_DISABLED`,
-and `SERVICE_INVALID`.
 
 ### `createView(args)`
 
@@ -304,7 +297,7 @@ Deprecated:
 
 ### `Admob.AD_LEFT_APPLICATION`
 
-DEPRECATED since 4.5.0. Use `leftapp` instead. 
+DEPRECATED since 4.5.0. Use `leftapp` instead.
 
 #### Example:
 
@@ -338,7 +331,7 @@ Deprecated:
 ## Support the Facebook Audience Network adapter
 
 Starting in 4.3.0 you can use the included Facebook Audience Network adapter to turn on the mediation in your AdMob account.
-Here you do not have to do anything 😙. You only need to configure mediation in your AdMob and Facebook accounts by 
+Here you do not have to do anything 😙. You only need to configure mediation in your AdMob and Facebook accounts by
 following the [official guide](https://developers.google.com/admob/android/mediation/facebook).
 
 WARNING! From version 4.5.0 the Facebook Audience Network adapter is deprecated. Once it is removed in a future release, it would depend

--- a/android/example/app.js
+++ b/android/example/app.js
@@ -13,10 +13,10 @@ var win = Titanium.UI.createWindow({
 var Admob = require('ti.admob');
 
 // check if google play services are available
-var code = Admob.isGooglePlayServicesAvailable();
-if (code != Admob.SUCCESS) {
-    alert("Google Play Services is not installed/updated/available");
-}
+// var code = Admob.isGooglePlayServicesAvailable();
+// if (code != Admob.SUCCESS) {
+//     alert("Google Play Services is not installed/updated/available");
+// }
 
 // then create an adMob view
 var adMobView = Admob.createView({
@@ -34,7 +34,7 @@ var adMobView = Admob.createView({
     linkColor: "#0000FF" //optional -  Link text color
     //primaryTextColor: "blue", // deprecated -- now maps to textColor
     //secondaryTextColor: "green" // deprecated -- now maps to linkColor
-    
+
 });
 
 // Create an Interstitial ad with a testing AdUnitId

--- a/android/manifest
+++ b/android/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 5.0.1
+version: 6.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: Titanium Admob module for Android

--- a/android/platform/README.md
+++ b/android/platform/README.md
@@ -1,0 +1,10 @@
+Files in this folder are copied directory into the Android build directory
+when the Android app is compiled:
+
+    <project-dir>/build/android
+
+You can place files such as res strings or drawable files.
+
+Files in this directory are copied directly on top of whatever files are already
+in the build directory, so please be careful that your files don't clobber
+essential project files or files from other modules.

--- a/android/platform/android/res/drawable/gnt_outline_shape.xml
+++ b/android/platform/android/res/drawable/gnt_outline_shape.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/gnt_white" />
+    <stroke
+        android:width="2dp"
+        android:color="@color/gnt_outline" />
+</shape>

--- a/android/platform/android/res/drawable/gnt_rounded_corners_shape.xml
+++ b/android/platform/android/res/drawable/gnt_rounded_corners_shape.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#ffffffff" />
+
+    <stroke
+        android:width="2dp"
+        android:color="@color/gnt_ad_green" />
+
+    <padding
+        android:bottom="1dp"
+        android:left="1dp"
+        android:right="1dp"
+        android:top="1dp" />
+
+    <corners
+        android:bottomLeftRadius="5dp"
+        android:bottomRightRadius="5dp"
+        android:topLeftRadius="5dp"
+        android:topRightRadius="5dp" />
+</shape>

--- a/android/platform/android/res/layout/layout.xml
+++ b/android/platform/android/res/layout/layout.xml
@@ -1,0 +1,127 @@
+<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:id="@+id/ad_app_icon"
+            android:layout_width="140dp"
+            android:layout_height="match_parent" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/content"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="@dimen/gnt_default_margin"
+            android:layout_marginEnd="@dimen/gnt_default_margin"
+            android:layout_marginTop="10dp"
+            android:layout_marginBottom="10dp">
+
+            <LinearLayout
+                android:id="@+id/headline"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/gnt_no_size"
+                android:layout_weight="@dimen/gnt_text_row_weight"
+                android:background="@android:color/transparent"
+                android:orientation="horizontal"
+                app:layout_constraintBottom_toTopOf="@+id/row_two"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:id="@+id/ad_headline"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_marginStart="@dimen/gnt_no_margin"
+                    android:layout_marginTop="@dimen/gnt_no_margin"
+                    android:layout_marginEnd="@dimen/gnt_no_margin"
+                    android:layout_marginBottom="@dimen/gnt_no_margin"
+                    android:lines="1"
+                    android:textColor="@color/gnt_gray"
+                    android:textSize="@dimen/gnt_text_size_large"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/row_two"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/gnt_no_size"
+                android:layout_weight="@dimen/gnt_text_row_weight"
+                android:orientation="horizontal"
+                app:layout_constraintBottom_toTopOf="@+id/cta"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/headline">
+
+                <TextView
+                    android:id="@+id/ad_notification_view"
+                    android:layout_width="@dimen/gnt_ad_indicator_width"
+                    android:layout_height="@dimen/gnt_ad_indicator_height"
+                    android:layout_marginStart="@dimen/gnt_no_margin"
+                    android:layout_marginTop="@dimen/gnt_ad_indicator_top_margin"
+                    android:layout_marginEnd="@dimen/gnt_default_margin"
+                    android:background="@drawable/gnt_rounded_corners_shape"
+                    android:gravity="center"
+                    android:text="Ad"
+                    android:textColor="@color/gnt_ad_green"
+                    android:textSize="@dimen/gnt_ad_indicator_text_size"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <RatingBar
+                    android:id="@+id/rating_bar"
+                    style="?android:attr/ratingBarStyleSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/gnt_no_margin"
+                    android:layout_marginTop="@dimen/gnt_no_margin"
+                    android:layout_marginEnd="@dimen/gnt_no_margin"
+                    android:layout_marginBottom="@dimen/gnt_no_margin"
+                    android:background="@android:color/transparent"
+                    android:lines="1"
+                    android:numStars="5"
+                    android:stepSize="0.1"
+                    android:textColor="@color/gnt_gray"
+                    android:textSize="@dimen/gnt_text_size_small"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/ad_notification_view"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                </RatingBar>
+
+
+            </LinearLayout>
+
+            <Button
+                android:id="@+id/cta"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/gnt_no_size"
+                android:background="@color/gnt_blue"
+                android:gravity="center"
+                android:lines="1"
+                android:textColor="@color/gnt_white"
+                android:textSize="12dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHeight_percent="0.35"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/row_two" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
+</com.google.android.gms.ads.nativead.NativeAdView>
+

--- a/android/platform/android/res/layout/layout_mediaview.xml
+++ b/android/platform/android/res/layout/layout_mediaview.xml
@@ -1,0 +1,142 @@
+<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/ad_app_icon"
+                android:layout_width="140dp"
+                android:layout_height="match_parent" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/content"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="@dimen/gnt_default_margin"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="@dimen/gnt_default_margin"
+                android:layout_marginBottom="10dp">
+
+                <LinearLayout
+                    android:id="@+id/headline"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/gnt_no_size"
+                    android:layout_weight="@dimen/gnt_text_row_weight"
+                    android:background="@android:color/transparent"
+                    android:orientation="horizontal"
+                    app:layout_constraintBottom_toTopOf="@+id/row_two"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <TextView
+                        android:id="@+id/ad_headline"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:layout_marginStart="@dimen/gnt_no_margin"
+                        android:layout_marginTop="@dimen/gnt_no_margin"
+                        android:layout_marginEnd="@dimen/gnt_no_margin"
+                        android:layout_marginBottom="@dimen/gnt_no_margin"
+                        android:lines="1"
+                        android:textColor="@color/gnt_gray"
+                        android:textSize="@dimen/gnt_text_size_large"
+                        android:textStyle="bold"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/row_two"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/gnt_no_size"
+                    android:layout_weight="@dimen/gnt_text_row_weight"
+                    android:orientation="horizontal"
+                    app:layout_constraintBottom_toTopOf="@+id/cta"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/headline">
+
+                    <TextView
+                        android:id="@+id/ad_notification_view"
+                        android:layout_width="@dimen/gnt_ad_indicator_width"
+                        android:layout_height="@dimen/gnt_ad_indicator_height"
+                        android:layout_marginStart="@dimen/gnt_no_margin"
+                        android:layout_marginTop="@dimen/gnt_ad_indicator_top_margin"
+                        android:layout_marginEnd="@dimen/gnt_default_margin"
+                        android:background="@drawable/gnt_rounded_corners_shape"
+                        android:gravity="center"
+                        android:text="Ad"
+                        android:textColor="@color/gnt_ad_green"
+                        android:textSize="@dimen/gnt_ad_indicator_text_size"
+                        android:textStyle="bold"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <RatingBar
+                        android:id="@+id/rating_bar"
+                        style="?android:attr/ratingBarStyleSmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/gnt_no_margin"
+                        android:layout_marginTop="@dimen/gnt_no_margin"
+                        android:layout_marginEnd="@dimen/gnt_no_margin"
+                        android:layout_marginBottom="@dimen/gnt_no_margin"
+                        android:background="@android:color/transparent"
+                        android:lines="1"
+                        android:numStars="5"
+                        android:stepSize="0.1"
+                        android:textColor="@color/gnt_gray"
+                        android:textSize="@dimen/gnt_text_size_small"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toEndOf="@id/ad_notification_view"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                    </RatingBar>
+
+
+                </LinearLayout>
+
+                <Button
+                    android:id="@+id/cta"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/gnt_no_size"
+                    android:background="@color/gnt_blue"
+                    android:gravity="center"
+                    android:lines="1"
+                    android:textColor="@color/gnt_white"
+                    android:textSize="12dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHeight_percent="0.35"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/row_two" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <com.google.android.gms.ads.nativead.MediaView
+                android:id="@+id/ad_mediaview"
+                android:layout_width="match_parent"
+                android:layout_height="300dp" />
+        </LinearLayout>
+    </LinearLayout>
+</com.google.android.gms.ads.nativead.NativeAdView>
+

--- a/android/platform/android/res/values/attrs.xml
+++ b/android/platform/android/res/values/attrs.xml
@@ -1,0 +1,5 @@
+<resources>
+    <declare-styleable name="TemplateView">
+        <attr name="gnt_template_type" format="reference" />
+    </declare-styleable>
+</resources>

--- a/android/platform/android/res/values/colors.xml
+++ b/android/platform/android/res/values/colors.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="gnt_test_background_color">#00F4F4F4</color>
+    <color name="gnt_test_background_color_2">#00A3A3A3</color>
+    <color name="gnt_black">#000000</color>
+    <color name="gnt_white">#FFFFFF</color>
+    <color name="gnt_red">#FF0000</color>
+    <color name="gnt_green">#00FF00</color>
+    <color name="gnt_blue">#4285f4</color>
+    <color name="gnt_ad_green">#3A6728</color>
+    <color name="gnt_gray">#808080</color>
+    <color name="gnt_outline">#E0E0E0</color>
+</resources>

--- a/android/platform/android/res/values/dimens.xml
+++ b/android/platform/android/res/values/dimens.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="gnt_medium_template_bottom_weight" format="float" type="dimen">0.4</item>
+    <item name="gnt_text_row_weight" format="float" type="dimen">0.25</item>
+    <item name="gnt_media_view_weight" format="float" type="dimen">1.0</item>
+    <item name="gnt_medium_template_top_weight" format="float" type="dimen">0.2</item>
+    <dimen name="gnt_default_margin">10dp</dimen>
+    <dimen name="gnt_small_margin">5dp</dimen>
+    <dimen name="gnt_text_size_small">12sp</dimen>
+    <dimen name="gnt_text_size_large">15sp</dimen>
+    <dimen name="gnt_ad_indicator_width">25dp</dimen>
+    <dimen name="gnt_ad_indicator_height">20dp</dimen>
+    <dimen name="gnt_ad_indicator_bar_height">30dp</dimen>
+    <dimen name="gnt_ad_indicator_top_margin">0dp</dimen>
+    <dimen name="gnt_ad_indicator_bottom_margin">10dp</dimen>
+    <dimen name="gnt_ad_indicator_text_size">10sp</dimen>
+    <dimen name="gnt_small_cta_button_height">30dp</dimen>
+    <dimen name="gnt_medium_cta_button_height">50dp</dimen>
+    <dimen name="gnt_no_margin">0dp</dimen>
+    <dimen name="gnt_no_size">0dp</dimen>
+</resources>

--- a/android/src/ti/admob/AdmobModule.java
+++ b/android/src/ti/admob/AdmobModule.java
@@ -8,11 +8,13 @@
 
 package ti.admob;
 
-import android.app.Activity;
+import android.annotation.SuppressLint;
 import android.content.Context;
-import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+
 import com.google.ads.consent.AdProvider;
 import com.google.ads.consent.ConsentForm;
 import com.google.ads.consent.ConsentFormListener;
@@ -24,16 +26,11 @@ import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.identifier.AdvertisingIdClient;
+import com.google.android.gms.ads.initialization.InitializationStatus;
+import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
-import com.google.android.gms.common.GooglePlayServicesUtil;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.KrollModule;
@@ -45,552 +42,518 @@ import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.io.TiBaseFile;
 import org.appcelerator.titanium.util.TiConvert;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
 @Kroll.module(name = "Admob", id = "ti.admob")
-public class AdmobModule extends KrollModule
-{
-	// Standard Debugging variables
-	private static final String TAG = "AdmobModule";
-	public static String MODULE_NAME = "AndroidAdMobModule";
-
-	private final String ANDROID_ADVERTISING_ID = "androidAdId";
-	private final String IS_LIMIT_AD_TRACKING_ENABLED = "isLimitAdTrackingEnabled";
-
-	public static Boolean TESTING = false;
-
-	private ConsentForm form = null;
-
-	public static String PUBLISHER_ID;
-
-	// properties
-	public static String PROPERTY_AD_SIZE = "adSize";
-	public static String PROPERTY_AD_UNIT_ID = "adUnitId";
-	public static String PROPERTY_DEBUG_ENABLED = "debugEnabled";
-	public static String PROPERTY_COLOR_BG = "adBackgroundColor";
-	public static String PROPERTY_COLOR_BG_TOP = "backgroundTopColor";
-	public static String PROPERTY_COLOR_BORDER = "borderColor";
-	public static String PROPERTY_COLOR_TEXT = "textColor";
-	public static String PROPERTY_COLOR_LINK = "linkColor";
-	public static String PROPERTY_COLOR_URL = "urlColor";
-	public static String PROPERTY_IS_TAGGED_FOR_UNDER_AGE_OF_CONSENT = "isTaggedForUnderAgeOfConsent";
-
-	// new event constans
-	public static final String EVENT_AD_LOAD = "load";
-	public static final String EVENT_AD_FAIL = "fail";
-	public static final String EVENT_AD_CLOSED = "close";
-	public static final String EVENT_AD_OPENED = "open";
-	public static final String EVENT_AD_LEFT_APP = "leftapp";
-
-	public AdmobModule()
-	{
-		super();
-		Log.d(TAG, "adMob module instantiated");
-	}
-
-	// Events for receiving ads
-	@Kroll.constant
-	public static final String AD_RECEIVED = "ad_received";
-	@Kroll.constant
-	public static final String AD_NOT_RECEIVED = "ad_not_received";
-	@Kroll.constant
-	public static final String AD_CLOSED = "ad_closed";
-	@Kroll.constant
-	public static final String AD_OPENED = "ad_opened";
-	@Kroll.constant
-	public static final String AD_LEFT_APPLICATION = "ad_left_application";
-
-	// Response from "isGooglePlayServicesAvailable()""
-	@Kroll.constant
-	public static final int SUCCESS = 0;
-	@Kroll.constant
-	public static final int SERVICE_MISSING = 1;
-	@Kroll.constant
-	public static final int SERVICE_VERSION_UPDATE_REQUIRED = 2;
-	@Kroll.constant
-	public static final int SERVICE_DISABLED = 3;
-	@Kroll.constant
-	public static final int SERVICE_INVALID = 9;
-
-	// Response from "consentStatus"
-	@Kroll.constant
-	public static final int CONSENT_STATUS_UNKNOWN = 0;
-	@Kroll.constant
-	public static final int CONSENT_STATUS_NON_PERSONALIZED = 1;
-	@Kroll.constant
-	public static final int CONSENT_STATUS_PERSONALIZED = 2;
-
-	// Debug geography constants
-	@Kroll.constant
-	public static final int DEBUG_GEOGRAPHY_DISABLED = 0;
-	@Kroll.constant
-	public static final int DEBUG_GEOGRAPHY_EEA = 1;
-	@Kroll.constant
-	public static final int DEBUG_GEOGRAPHY_NOT_EEA = 3;
-
-	// AdSize constants
-	@Kroll.constant
-	public static final int AD_SIZE_BANNER = 0;
-	@Kroll.constant
-	public static final int AD_SIZE_FLUID = 1;
-	@Kroll.constant
-	public static final int AD_SIZE_FULL_BANNER = 2;
-	@Kroll.constant
-	public static final int AD_SIZE_LARGE_BANNER = 3;
-	@Kroll.constant
-	public static final int AD_SIZE_LEADERBOARD = 4;
-	@Kroll.constant
-	public static final int AD_SIZE_MEDIUM_RECTANGLE = 5;
-	@Kroll.constant
-	public static final int AD_SIZE_SEARCH = 6;
-	@Kroll.constant
-	public static final int AD_SIZE_SMART_BANNER = 7;
-	@Kroll.constant
-	public static final int AD_SIZE_WIDE_SKYSCRAPER = 8;
-
-	@Kroll.constant
-	public static final String SIMULATOR_ID = AdRequest.DEVICE_ID_EMULATOR;
-
-	@Kroll.method
-	public void initialize(String appID)
-	{
-		MobileAds.initialize(TiApplication.getInstance(), appID);
-	}
-
-	@Kroll.method
-	public int isGooglePlayServicesAvailable()
-	{
-		Log.w(TAG, "isGooglePlayServices in ti.admob is deprecated. Use the same method from ti.playservices instead.");
-		return GooglePlayServicesUtil.isGooglePlayServicesAvailable(TiApplication.getAppRootOrCurrentActivity());
-	}
-
-	// clang-format off
-	@Kroll.setProperty
-	@Kroll.method
-	public void setPublisherId(String pubId)
-	// clang-format on
-	{
-		Log.d(TAG, "setPublisherId(): " + pubId);
-		PUBLISHER_ID = pubId;
-	}
-
-	@Kroll.method
-	public void setTesting(boolean testing)
-	{
-		Log.d(TAG, "setTesting(): " + testing);
-		TESTING = testing;
-	}
-
-	@Kroll.method
-	public void isLimitAdTrackingEnabled(KrollFunction callback)
-	{
-		if (callback != null) {
-			new getAndroidAdvertisingIDInfo(callback).execute(IS_LIMIT_AD_TRACKING_ENABLED);
-		}
-	}
-
-	@Kroll.method
-	public void getAndroidAdId(KrollFunction callback)
-	{
-		if (callback != null) {
-			new getAndroidAdvertisingIDInfo(callback).execute(ANDROID_ADVERTISING_ID);
-		}
-	}
-
-	private void invokeAIDClientInfoCallback(AdvertisingIdClient.Info aaClientIDInfo, String responseKey,
-											 KrollFunction callback)
-	{
-		KrollDict callbackDictionary = new KrollDict();
-		Object responseValue = null;
-		switch (responseKey) {
-			case ANDROID_ADVERTISING_ID:
-				responseValue = aaClientIDInfo.getId();
-				break;
-			case IS_LIMIT_AD_TRACKING_ENABLED:
-				responseValue = aaClientIDInfo.isLimitAdTrackingEnabled();
-				break;
-		}
-		callbackDictionary.put(responseKey, responseValue);
-		callback.callAsync(getKrollObject(), callbackDictionary);
-	}
-
-	private class getAndroidAdvertisingIDInfo extends AsyncTask<String, Integer, String>
-	{
-
-		private AdvertisingIdClient.Info aaClientIDInfo = null;
-		private KrollFunction aaInfoCallback;
-
-		public getAndroidAdvertisingIDInfo(KrollFunction infoCallback)
-		{
-			this.aaInfoCallback = infoCallback;
-		}
-
-		@Override
-		protected String doInBackground(String... responseKey)
-		{
-			try {
-				aaClientIDInfo =
-					AdvertisingIdClient.getAdvertisingIdInfo(TiApplication.getInstance().getApplicationContext());
-				return responseKey[0];
-			} catch (IOException | GooglePlayServicesNotAvailableException | GooglePlayServicesRepairableException e) {
-				e.printStackTrace();
-				return null;
-			}
-		}
-
-		@Override
-		protected void onPostExecute(String responseKey)
-		{
-			if (aaClientIDInfo != null) {
-				invokeAIDClientInfoCallback(aaClientIDInfo, responseKey, aaInfoCallback);
-			}
-		}
-	}
-
-	@Kroll.method
-	public void requestConsentInfoUpdateForPublisherIdentifiers(KrollDict args)
-	{
-		String[] publisherIdentifiers = args.getStringArray("publisherIdentifiers");
-		final KrollFunction callback;
-		{
-			Object value = args.get("callback");
-			if (value instanceof KrollFunction) {
-				callback = (KrollFunction) value;
-			} else {
-				throw new RuntimeException("The 'callback' property is required and must be set to a function.");
-			}
-		}
-
-		Context appContext = TiApplication.getInstance().getApplicationContext();
-
-		ConsentInformation consentInformation = ConsentInformation.getInstance(appContext);
-		consentInformation.requestConsentInfoUpdate(publisherIdentifiers, new ConsentInfoUpdateListener() {
-			@Override
-			public void onConsentInfoUpdated(ConsentStatus consentStatus)
-			{
-				Log.d(TAG, "consent info updated");
-
-				KrollObject krollObject = getKrollObject();
-				KrollDict event = new KrollDict();
-
-				event.put("consentStatus", consentStatus.ordinal());
-
-				callback.callAsync(krollObject, event);
-			}
-
-			@Override
-			public void onFailedToUpdateConsentInfo(String errorReason)
-			{
-				Log.d(TAG, "consent info failed");
-
-				KrollObject krollObject = getKrollObject();
-				KrollDict event = new KrollDict();
-
-				event.put("error", errorReason);
-
-				callback.callAsync(krollObject, event);
-			}
-		});
-	}
-
-	@Kroll.method
-	public void showConsentForm(KrollDict args)
-	{
-		URL privacyUrl = null;
-		Context currentActivity = TiApplication.getInstance().getCurrentActivity();
-
-		final KrollFunction callback;
-		{
-			Object value = args.get("callback");
-			if (value instanceof KrollFunction) {
-				callback = (KrollFunction) value;
-			} else {
-				throw new RuntimeException("The 'callback' property is required and must be set to a function.");
-			}
-		}
-
-		boolean shouldOfferPersonalizedAds = args.optBoolean("shouldOfferPersonalizedAds", true);
-		boolean shouldOfferNonPersonalizedAds = args.optBoolean("shouldOfferNonPersonalizedAds", true);
-		boolean shouldOfferAdFree = args.optBoolean("shouldOfferAdFree", false);
-
-		try {
-			privacyUrl = new URL(args.getString("privacyURL"));
-		} catch (Exception e) {
-			KrollObject krollObject = getKrollObject();
-			KrollDict event = new KrollDict();
-
-			event.put("error", e.getMessage());
-
-			callback.callAsync(krollObject, event);
-			return;
-		}
-
-		ConsentForm.Builder formBuilder =
-			new ConsentForm.Builder(currentActivity, privacyUrl).withListener(new ConsentFormListener() {
-				@Override
-				public void onConsentFormLoaded()
-				{
-					Log.d(TAG, "consent form loaded");
-					if (form != null) {
-						form.show();
-					}
-				}
-
-				@Override
-				public void onConsentFormOpened()
-				{
-					Log.d(TAG, "consent form opened");
-				}
-
-				@Override
-				public void onConsentFormClosed(ConsentStatus consentStatus, Boolean userPrefersAdFree)
-				{
-					Log.d(TAG, "consent form closed");
-
-					KrollObject krollObject = getKrollObject();
-					KrollDict event = new KrollDict();
-
-					event.put("userPrefersAdFree", userPrefersAdFree);
-					event.put("consentStatus", consentStatus.ordinal());
-					event.put("error", null);
-
-					callback.callAsync(krollObject, event);
-				}
-
-				@Override
-				public void onConsentFormError(String errorDescription)
-				{
-					Log.d(TAG, "consent form error: " + errorDescription);
-
-					KrollObject krollObject = getKrollObject();
-					KrollDict event = new KrollDict();
-
-					event.put("error", errorDescription);
-
-					callback.callAsync(krollObject, event);
-				}
-			});
-
-		if (shouldOfferPersonalizedAds) {
-			formBuilder = formBuilder.withPersonalizedAdsOption();
-		}
-
-		if (shouldOfferNonPersonalizedAds) {
-			formBuilder = formBuilder.withNonPersonalizedAdsOption();
-		}
-
-		if (shouldOfferAdFree) {
-			formBuilder = formBuilder.withAdFreeOption();
-		}
-
-		form = formBuilder.build();
-		runOnMainThread(new Runnable() {
-			@Override
-			public void run()
-			{
-				form.load();
-			}
-		});
-	}
-
-	// clang-format off
-	@Kroll.setProperty
-	public void setIsTaggedForUnderAgeOfConsent(boolean underAgeOfConsent)
-	// clang-format on
-	{
-		Context appContext = TiApplication.getInstance().getApplicationContext();
-		ConsentInformation.getInstance(appContext).setTagForUnderAgeOfConsent(underAgeOfConsent);
-	}
-
-	@Kroll.method
-	public void setTagForUnderAgeOfConsent(boolean underAgeOfConsent)
-	{
-		Log.w(TAG, "setTagForUnderAgeOfConsent is deprecated. Use <setIsTaggedForUnderAgeOfConsent> property instead.");
-		Context appContext = TiApplication.getInstance().getApplicationContext();
-		ConsentInformation.getInstance(appContext).setTagForUnderAgeOfConsent(underAgeOfConsent);
-	}
-
-	@Kroll.getProperty
-	@Kroll.method
-	public boolean getIsTaggedForUnderAgeOfConsent()
-	{
-		Context appContext = TiApplication.getInstance().getApplicationContext();
-		return ConsentInformation.getInstance(appContext).isTaggedForUnderAgeOfConsent();
-	}
-
-	// clang-format off
-	@Kroll.getProperty
-	@Kroll.method
-	public int getConsentStatus()
-	// clang-format on
-	{
-		Context appContext = TiApplication.getInstance().getApplicationContext();
-		return ConsentInformation.getInstance(appContext).getConsentStatus().ordinal();
-	}
-
-	// clang-format off
-	@Kroll.getProperty
-	@Kroll.method
-	public int getDebugGeography()
-	// clang-format on
-	{
-		Context appContext = TiApplication.getInstance().getApplicationContext();
-		return ConsentInformation.getInstance(appContext).getDebugGeography().ordinal();
-	}
-
-	// clang-format off
-	@Kroll.setProperty
-	@Kroll.method
-	public void setDebugGeography(int debugGeography)
-	// clang-format on
-	{
-		Context appContext = TiApplication.getInstance().getApplicationContext();
-		ConsentInformation.getInstance(appContext).setDebugGeography(DebugGeography.values()[debugGeography]);
-	}
-
-	@Kroll.method
-	public void resetConsent()
-	{
-		Context appContext = TiApplication.getInstance().getApplicationContext();
-		ConsentInformation.getInstance(appContext).reset();
-	}
-
-	// clang-format off
-	@Kroll.getProperty
-	@Kroll.method
-	public KrollDict[] getAdProviders()
-	// clang-format on
-	{
-		Context appContext = TiApplication.getInstance().getApplicationContext();
-		List<AdProvider> adProviders = ConsentInformation.getInstance(appContext).getAdProviders();
-		KrollDict[] result = new KrollDict[adProviders.size()];
-
-		for (int i = 0; i < adProviders.size(); i++) {
-			AdProvider adProvider = adProviders.get(i);
-			KrollDict dict = new KrollDict();
-
-			dict.put("identifier", adProvider.getId());
-			dict.put("name", adProvider.getName());
-			dict.put("privacyPolicyURL", adProvider.getPrivacyPolicyUrlString());
-
-			result[i] = dict;
-		}
-
-		return result;
-	}
-
-	public static Bundle mapToBundle(Map<String, Object> map)
-	{
-		if (map == null) {
-			return new Bundle();
-		}
-
-		Bundle bundle = new Bundle(map.size());
-
-		for (String key : map.keySet()) {
-			Object val = map.get(key);
-			if (val == null) {
-				bundle.putString(key, null);
-			} else if (val instanceof TiBlob) {
-				bundle.putByteArray(key, ((TiBlob) val).getBytes());
-			} else if (val instanceof TiBaseFile) {
-				try {
-					bundle.putByteArray(key, ((TiBaseFile) val).read().getBytes());
-				} catch (IOException e) {
-					Log.e(TAG, "Unable to put '" + key + "' value into bundle: " + e.getLocalizedMessage(), e);
-				}
-			} else if (val instanceof AdmobSizeProxy) {
-				//
-			} else {
-				bundle.putString(key, TiConvert.toString(val));
-			}
-		}
-
-		return bundle;
-	}
-
-	public static AdRequest.Builder createRequestBuilderWithOptions(KrollDict options)
-	{
-		AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
-		if (options == null) {
-			return adRequestBuilder;
-		}
-		Bundle bundle = createAdRequestExtrasBundleFromDictionary(options.getKrollDict("extras"));
-		if (bundle.size() > 0) {
-			adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);
-		}
-		// Handle keywords
-		if (options.containsKeyAndNotNull("keywords")) {
-			String[] keywords = options.getStringArray("keywords");
-			for (int i = 0; i < keywords.length; i++) {
-				adRequestBuilder.addKeyword(keywords[i]);
-			}
-		}
-		// Handle contentURL
-		if (options.containsKeyAndNotNull("contentURL")) {
-			adRequestBuilder.setContentUrl(options.getString("contentURL"));
-		}
-		// Handle tagForChildDirectedTreatment
-		if (options.containsKeyAndNotNull("tagForChildDirectedTreatment")) {
-			adRequestBuilder.tagForChildDirectedTreatment(options.getBoolean("tagForChildDirectedTreatment"));
-		}
-		// Handle requestAgent
-		if (options.containsKeyAndNotNull("requestAgent")) {
-			adRequestBuilder.setRequestAgent(options.getString("requestAgent"));
-		}
-		// Handle testDevices
-		if (options.containsKeyAndNotNull("testDevices")) {
-			String[] testDevices = options.getStringArray("testDevices");
-			for (int i = 0; i < testDevices.length; i++) {
-				adRequestBuilder.addTestDevice(testDevices[i]);
-			}
-		}
-		return adRequestBuilder;
-	}
-
-	// create the adRequest extras bundle
-	private static Bundle createAdRequestExtrasBundleFromDictionary(KrollDict extrasDictionary)
-	{
-		Bundle bundle = new Bundle();
-		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_BG)) {
-			bundle.putString("color_bg", convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_BG)));
-		}
-		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_BG_TOP)) {
-			bundle.putString("color_bg_top",
-							 convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_BG_TOP)));
-		}
-		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_BORDER)) {
-			bundle.putString("color_border",
-							 convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_BORDER)));
-		}
-		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_TEXT)) {
-			bundle.putString("color_text",
-							 convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_TEXT)));
-		}
-		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_LINK)) {
-			bundle.putString("color_link",
-							 convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_LINK)));
-		}
-		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_URL)) {
-			bundle.putString("color_url", convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_URL)));
-		}
-		return bundle;
-	}
-
-	// modifies the color prop -- removes # and changes constants into hex values
-	public static String convertColorProp(String color)
-	{
-		color = color.replace("#", "");
-		if (color.equals("white"))
-			color = "FFFFFF";
-		if (color.equals("red"))
-			color = "FF0000";
-		if (color.equals("blue"))
-			color = "0000FF";
-		if (color.equals("green"))
-			color = "008000";
-		if (color.equals("yellow"))
-			color = "FFFF00";
-		if (color.equals("black"))
-			color = "000000";
-		return color;
-	}
+public class AdmobModule extends KrollModule {
+    // new event constans
+    public static final String EVENT_AD_LOAD = "load";
+    public static final String EVENT_AD_FAIL = "fail";
+    public static final String EVENT_AD_CLOSED = "close";
+    public static final String EVENT_AD_OPENED = "open";
+    public static final String EVENT_AD_LEFT_APP = "leftapp";
+    // Events for receiving ads
+    @Kroll.constant
+    public static final String AD_RECEIVED = "ad_received";
+    @Kroll.constant
+    public static final String AD_NOT_RECEIVED = "ad_not_received";
+    @Kroll.constant
+    public static final String AD_CLOSED = "ad_closed";
+    @Kroll.constant
+    public static final String AD_OPENED = "ad_opened";
+    @Kroll.constant
+    public static final String AD_LEFT_APPLICATION = "ad_left_application";
+    // Response from "isGooglePlayServicesAvailable()""
+    @Kroll.constant
+    public static final int SUCCESS = 0;
+    @Kroll.constant
+    public static final int SERVICE_MISSING = 1;
+    @Kroll.constant
+    public static final int SERVICE_VERSION_UPDATE_REQUIRED = 2;
+    @Kroll.constant
+    public static final int SERVICE_DISABLED = 3;
+    @Kroll.constant
+    public static final int SERVICE_INVALID = 9;
+    // Response from "consentStatus"
+    @Kroll.constant
+    public static final int CONSENT_STATUS_UNKNOWN = 0;
+    @Kroll.constant
+    public static final int CONSENT_STATUS_NON_PERSONALIZED = 1;
+    @Kroll.constant
+    public static final int CONSENT_STATUS_PERSONALIZED = 2;
+    // Debug geography constants
+    @Kroll.constant
+    public static final int DEBUG_GEOGRAPHY_DISABLED = 0;
+    @Kroll.constant
+    public static final int DEBUG_GEOGRAPHY_EEA = 1;
+    @Kroll.constant
+    public static final int DEBUG_GEOGRAPHY_NOT_EEA = 3;
+    // AdSize constants
+    @Kroll.constant
+    public static final int AD_SIZE_BANNER = 0;
+    @Kroll.constant
+    public static final int AD_SIZE_FLUID = 1;
+    @Kroll.constant
+    public static final int AD_SIZE_FULL_BANNER = 2;
+    @Kroll.constant
+    public static final int AD_SIZE_LARGE_BANNER = 3;
+    @Kroll.constant
+    public static final int AD_SIZE_LEADERBOARD = 4;
+    @Kroll.constant
+    public static final int AD_SIZE_MEDIUM_RECTANGLE = 5;
+    @Kroll.constant
+    public static final int AD_SIZE_SEARCH = 6;
+    @Kroll.constant
+    public static final int AD_SIZE_SMART_BANNER = 7;
+    @Kroll.constant
+    public static final int AD_SIZE_WIDE_SKYSCRAPER = 8;
+    @Kroll.constant
+    public static final String SIMULATOR_ID = AdRequest.DEVICE_ID_EMULATOR;
+    // Standard Debugging variables
+    private static final String TAG = "AdmobModule";
+    public static String MODULE_NAME = "AndroidAdMobModule";
+    public static Boolean TESTING = false;
+    public static String PUBLISHER_ID;
+    // properties
+    public static String PROPERTY_AD_SIZE = "adSize";
+    public static String PROPERTY_AD_UNIT_ID = "adUnitId";
+    public static String PROPERTY_DEBUG_ENABLED = "debugEnabled";
+    public static String PROPERTY_COLOR_BG = "adBackgroundColor";
+    public static String PROPERTY_COLOR_BG_TOP = "backgroundTopColor";
+    public static String PROPERTY_COLOR_BORDER = "borderColor";
+    public static String PROPERTY_COLOR_TEXT = "textColor";
+    public static String PROPERTY_COLOR_LINK = "linkColor";
+    public static String PROPERTY_COLOR_URL = "urlColor";
+    public static String PROPERTY_IS_TAGGED_FOR_UNDER_AGE_OF_CONSENT = "isTaggedForUnderAgeOfConsent";
+    private final String ANDROID_ADVERTISING_ID = "androidAdId";
+    private final String IS_LIMIT_AD_TRACKING_ENABLED = "isLimitAdTrackingEnabled";
+    private ConsentForm form = null;
+
+    public AdmobModule() {
+        super();
+        Log.d(TAG, "adMob module instantiated");
+    }
+
+    public static Bundle mapToBundle(Map<String, Object> map) {
+        if (map == null) {
+            return new Bundle();
+        }
+
+        Bundle bundle = new Bundle(map.size());
+
+        for (String key : map.keySet()) {
+            Object val = map.get(key);
+            if (val == null) {
+                bundle.putString(key, null);
+            } else if (val instanceof TiBlob) {
+                bundle.putByteArray(key, ((TiBlob) val).getBytes());
+            } else if (val instanceof TiBaseFile) {
+                try {
+                    bundle.putByteArray(key, ((TiBaseFile) val).read().getBytes());
+                } catch (IOException e) {
+                    Log.e(TAG, "Unable to put '" + key + "' value into bundle: " + e.getLocalizedMessage(), e);
+                }
+            } else if (val instanceof AdmobSizeProxy) {
+                //
+            } else {
+                bundle.putString(key, TiConvert.toString(val));
+            }
+        }
+
+        return bundle;
+    }
+
+    public static AdRequest.Builder createRequestBuilderWithOptions(KrollDict options) {
+        AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
+        if (options == null) {
+            return adRequestBuilder;
+        }
+        Bundle bundle = createAdRequestExtrasBundleFromDictionary(options.getKrollDict("extras"));
+        if (bundle.size() > 0) {
+            adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);
+        }
+        // Handle keywords
+        if (options.containsKeyAndNotNull("keywords")) {
+            String[] keywords = options.getStringArray("keywords");
+            for (int i = 0; i < keywords.length; i++) {
+                adRequestBuilder.addKeyword(keywords[i]);
+            }
+        }
+        // Handle contentURL
+        if (options.containsKeyAndNotNull("contentURL")) {
+            adRequestBuilder.setContentUrl(options.getString("contentURL"));
+        }
+        // Handle tagForChildDirectedTreatment
+        if (options.containsKeyAndNotNull("tagForChildDirectedTreatment")) {
+            // adRequestBuilder.tagForChildDirectedTreatment(options.getBoolean("tagForChildDirectedTreatment"));
+        }
+        // Handle requestAgent
+        if (options.containsKeyAndNotNull("requestAgent")) {
+            adRequestBuilder.setRequestAgent(options.getString("requestAgent"));
+        }
+        // Handle testDevices
+        if (options.containsKeyAndNotNull("testDevices")) {
+            String[] testDevices = options.getStringArray("testDevices");
+            for (int i = 0; i < testDevices.length; i++) {
+                // adRequestBuilder.addTestDevice(testDevices[i]);
+            }
+        }
+        return adRequestBuilder;
+    }
+
+    // create the adRequest extras bundle
+    private static Bundle createAdRequestExtrasBundleFromDictionary(KrollDict extrasDictionary) {
+        Bundle bundle = new Bundle();
+        if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_BG)) {
+            bundle.putString("color_bg", convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_BG)));
+        }
+        if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_BG_TOP)) {
+            bundle.putString("color_bg_top",
+                    convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_BG_TOP)));
+        }
+        if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_BORDER)) {
+            bundle.putString("color_border",
+                    convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_BORDER)));
+        }
+        if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_TEXT)) {
+            bundle.putString("color_text",
+                    convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_TEXT)));
+        }
+        if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_LINK)) {
+            bundle.putString("color_link",
+                    convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_LINK)));
+        }
+        if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_URL)) {
+            bundle.putString("color_url", convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_URL)));
+        }
+        return bundle;
+    }
+
+    // modifies the color prop -- removes # and changes constants into hex values
+    public static String convertColorProp(String color) {
+        color = color.replace("#", "");
+        if (color.equals("white"))
+            color = "FFFFFF";
+        if (color.equals("red"))
+            color = "FF0000";
+        if (color.equals("blue"))
+            color = "0000FF";
+        if (color.equals("green"))
+            color = "008000";
+        if (color.equals("yellow"))
+            color = "FFFF00";
+        if (color.equals("black"))
+            color = "000000";
+        return color;
+    }
+
+    @Kroll.method
+    public void initialize(String appID) {
+        MobileAds.initialize(TiApplication.getInstance(), new OnInitializationCompleteListener() {
+            @Override
+            public void onInitializationComplete(@NonNull InitializationStatus initializationStatus) {
+
+            }
+        });
+    }
+
+    // clang-format off
+    @Kroll.setProperty
+    @Kroll.method
+    public void setPublisherId(String pubId)
+    // clang-format on
+    {
+        Log.d(TAG, "setPublisherId(): " + pubId);
+        PUBLISHER_ID = pubId;
+    }
+
+    @Kroll.method
+    public void setTesting(boolean testing) {
+        Log.d(TAG, "setTesting(): " + testing);
+        TESTING = testing;
+    }
+
+    @Kroll.method
+    public void isLimitAdTrackingEnabled(KrollFunction callback) {
+        if (callback != null) {
+            new getAndroidAdvertisingIDInfo(callback).execute(IS_LIMIT_AD_TRACKING_ENABLED);
+        }
+    }
+
+    @Kroll.method
+    public void getAndroidAdId(KrollFunction callback) {
+        if (callback != null) {
+            new getAndroidAdvertisingIDInfo(callback).execute(ANDROID_ADVERTISING_ID);
+        }
+    }
+
+    private void invokeAIDClientInfoCallback(AdvertisingIdClient.Info aaClientIDInfo, String responseKey,
+                                             KrollFunction callback) {
+        KrollDict callbackDictionary = new KrollDict();
+        Object responseValue = null;
+        switch (responseKey) {
+            case ANDROID_ADVERTISING_ID:
+                responseValue = aaClientIDInfo.getId();
+                break;
+            case IS_LIMIT_AD_TRACKING_ENABLED:
+                responseValue = aaClientIDInfo.isLimitAdTrackingEnabled();
+                break;
+        }
+        callbackDictionary.put(responseKey, responseValue);
+        callback.callAsync(getKrollObject(), callbackDictionary);
+    }
+
+    @Kroll.method
+    public void requestConsentInfoUpdateForPublisherIdentifiers(KrollDict args) {
+        String[] publisherIdentifiers = args.getStringArray("publisherIdentifiers");
+        final KrollFunction callback;
+        {
+            Object value = args.get("callback");
+            if (value instanceof KrollFunction) {
+                callback = (KrollFunction) value;
+            } else {
+                throw new RuntimeException("The 'callback' property is required and must be set to a function.");
+            }
+        }
+
+        Context appContext = TiApplication.getInstance().getApplicationContext();
+
+        ConsentInformation consentInformation = ConsentInformation.getInstance(appContext);
+        consentInformation.requestConsentInfoUpdate(publisherIdentifiers, new ConsentInfoUpdateListener() {
+            @Override
+            public void onConsentInfoUpdated(ConsentStatus consentStatus) {
+                Log.d(TAG, "consent info updated");
+
+                KrollObject krollObject = getKrollObject();
+                KrollDict event = new KrollDict();
+
+                event.put("consentStatus", consentStatus.ordinal());
+
+                callback.callAsync(krollObject, event);
+            }
+
+            @Override
+            public void onFailedToUpdateConsentInfo(String errorReason) {
+                Log.d(TAG, "consent info failed");
+
+                KrollObject krollObject = getKrollObject();
+                KrollDict event = new KrollDict();
+
+                event.put("error", errorReason);
+
+                callback.callAsync(krollObject, event);
+            }
+        });
+    }
+
+    @Kroll.method
+    public void showConsentForm(KrollDict args) {
+        URL privacyUrl = null;
+        Context currentActivity = TiApplication.getInstance().getCurrentActivity();
+
+        final KrollFunction callback;
+        {
+            Object value = args.get("callback");
+            if (value instanceof KrollFunction) {
+                callback = (KrollFunction) value;
+            } else {
+                throw new RuntimeException("The 'callback' property is required and must be set to a function.");
+            }
+        }
+
+        boolean shouldOfferPersonalizedAds = args.optBoolean("shouldOfferPersonalizedAds", true);
+        boolean shouldOfferNonPersonalizedAds = args.optBoolean("shouldOfferNonPersonalizedAds", true);
+        boolean shouldOfferAdFree = args.optBoolean("shouldOfferAdFree", false);
+
+        try {
+            privacyUrl = new URL(args.getString("privacyURL"));
+        } catch (Exception e) {
+            KrollObject krollObject = getKrollObject();
+            KrollDict event = new KrollDict();
+
+            event.put("error", e.getMessage());
+
+            callback.callAsync(krollObject, event);
+            return;
+        }
+
+        ConsentForm.Builder formBuilder =
+                new ConsentForm.Builder(currentActivity, privacyUrl).withListener(new ConsentFormListener() {
+                    @Override
+                    public void onConsentFormLoaded() {
+                        Log.d(TAG, "consent form loaded");
+                        if (form != null) {
+                            form.show();
+                        }
+                    }
+
+                    @Override
+                    public void onConsentFormOpened() {
+                        Log.d(TAG, "consent form opened");
+                    }
+
+                    @Override
+                    public void onConsentFormClosed(ConsentStatus consentStatus, Boolean userPrefersAdFree) {
+                        Log.d(TAG, "consent form closed");
+
+                        KrollObject krollObject = getKrollObject();
+                        KrollDict event = new KrollDict();
+
+                        event.put("userPrefersAdFree", userPrefersAdFree);
+                        event.put("consentStatus", consentStatus.ordinal());
+                        event.put("error", null);
+
+                        callback.callAsync(krollObject, event);
+                    }
+
+                    @Override
+                    public void onConsentFormError(String errorDescription) {
+                        Log.d(TAG, "consent form error: " + errorDescription);
+
+                        KrollObject krollObject = getKrollObject();
+                        KrollDict event = new KrollDict();
+
+                        event.put("error", errorDescription);
+
+                        callback.callAsync(krollObject, event);
+                    }
+                });
+
+        if (shouldOfferPersonalizedAds) {
+            formBuilder = formBuilder.withPersonalizedAdsOption();
+        }
+
+        if (shouldOfferNonPersonalizedAds) {
+            formBuilder = formBuilder.withNonPersonalizedAdsOption();
+        }
+
+        if (shouldOfferAdFree) {
+            formBuilder = formBuilder.withAdFreeOption();
+        }
+
+        form = formBuilder.build();
+        runOnMainThread(new Runnable() {
+            @Override
+            public void run() {
+                form.load();
+            }
+        });
+    }
+
+    @Kroll.method
+    public void setTagForUnderAgeOfConsent(boolean underAgeOfConsent) {
+        Log.w(TAG, "setTagForUnderAgeOfConsent is deprecated. Use <setIsTaggedForUnderAgeOfConsent> property instead.");
+        Context appContext = TiApplication.getInstance().getApplicationContext();
+        ConsentInformation.getInstance(appContext).setTagForUnderAgeOfConsent(underAgeOfConsent);
+    }
+
+    @Kroll.getProperty
+    @Kroll.method
+    public boolean getIsTaggedForUnderAgeOfConsent() {
+        Context appContext = TiApplication.getInstance().getApplicationContext();
+        return ConsentInformation.getInstance(appContext).isTaggedForUnderAgeOfConsent();
+    }
+
+    // clang-format off
+    @Kroll.setProperty
+    public void setIsTaggedForUnderAgeOfConsent(boolean underAgeOfConsent)
+    // clang-format on
+    {
+        Context appContext = TiApplication.getInstance().getApplicationContext();
+        ConsentInformation.getInstance(appContext).setTagForUnderAgeOfConsent(underAgeOfConsent);
+    }
+
+    // clang-format off
+    @Kroll.getProperty
+    @Kroll.method
+    public int getConsentStatus()
+    // clang-format on
+    {
+        Context appContext = TiApplication.getInstance().getApplicationContext();
+        return ConsentInformation.getInstance(appContext).getConsentStatus().ordinal();
+    }
+
+    // clang-format off
+    @Kroll.getProperty
+    @Kroll.method
+    public int getDebugGeography()
+    // clang-format on
+    {
+        Context appContext = TiApplication.getInstance().getApplicationContext();
+        return ConsentInformation.getInstance(appContext).getDebugGeography().ordinal();
+    }
+
+    // clang-format off
+    @Kroll.setProperty
+    @Kroll.method
+    public void setDebugGeography(int debugGeography)
+    // clang-format on
+    {
+        Context appContext = TiApplication.getInstance().getApplicationContext();
+        ConsentInformation.getInstance(appContext).setDebugGeography(DebugGeography.values()[debugGeography]);
+    }
+
+    @Kroll.method
+    public void resetConsent() {
+        Context appContext = TiApplication.getInstance().getApplicationContext();
+        ConsentInformation.getInstance(appContext).reset();
+    }
+
+    // clang-format off
+    @Kroll.getProperty
+    @Kroll.method
+    public KrollDict[] getAdProviders()
+    // clang-format on
+    {
+        Context appContext = TiApplication.getInstance().getApplicationContext();
+        List<AdProvider> adProviders = ConsentInformation.getInstance(appContext).getAdProviders();
+        KrollDict[] result = new KrollDict[adProviders.size()];
+
+        for (int i = 0; i < adProviders.size(); i++) {
+            AdProvider adProvider = adProviders.get(i);
+            KrollDict dict = new KrollDict();
+
+            dict.put("identifier", adProvider.getId());
+            dict.put("name", adProvider.getName());
+            dict.put("privacyPolicyURL", adProvider.getPrivacyPolicyUrlString());
+
+            result[i] = dict;
+        }
+
+        return result;
+    }
+
+    @SuppressLint("StaticFieldLeak")
+    private class getAndroidAdvertisingIDInfo extends AsyncTask<String, Integer, String> {
+
+        private final KrollFunction aaInfoCallback;
+        private AdvertisingIdClient.Info aaClientIDInfo = null;
+
+        public getAndroidAdvertisingIDInfo(KrollFunction infoCallback) {
+            this.aaInfoCallback = infoCallback;
+        }
+
+        @Override
+        protected String doInBackground(String... responseKey) {
+            try {
+                aaClientIDInfo =
+                        AdvertisingIdClient.getAdvertisingIdInfo(TiApplication.getInstance().getApplicationContext());
+                return responseKey[0];
+            } catch (IOException | GooglePlayServicesNotAvailableException |
+                     GooglePlayServicesRepairableException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+
+        @Override
+        protected void onPostExecute(String responseKey) {
+            if (aaClientIDInfo != null) {
+                invokeAIDClientInfoCallback(aaClientIDInfo, responseKey, aaInfoCallback);
+            }
+        }
+    }
 }

--- a/android/src/ti/admob/AdmobSizeEnum.java
+++ b/android/src/ti/admob/AdmobSizeEnum.java
@@ -11,37 +11,34 @@ import com.google.android.gms.ads.AdSize;
 
 public enum AdmobSizeEnum {
 
-	BANNER(AdmobModule.AD_SIZE_BANNER, AdSize.BANNER),
-	FLUID(AdmobModule.AD_SIZE_FLUID, AdSize.FLUID),
-	FULL_BANNER(AdmobModule.AD_SIZE_FULL_BANNER, AdSize.FULL_BANNER),
-	LARGE_BANNER(AdmobModule.AD_SIZE_LARGE_BANNER, AdSize.LARGE_BANNER),
-	LEADERBOARD(AdmobModule.AD_SIZE_LEADERBOARD, AdSize.LEADERBOARD),
-	MEDIUM_RECTANGLE(AdmobModule.AD_SIZE_MEDIUM_RECTANGLE, AdSize.MEDIUM_RECTANGLE),
-	SEARCH(AdmobModule.AD_SIZE_SEARCH, AdSize.SEARCH),
-	SMART_BANNER(AdmobModule.AD_SIZE_SMART_BANNER, AdSize.SMART_BANNER),
-	WIDE_SKYSCRAPER(AdmobModule.AD_SIZE_WIDE_SKYSCRAPER, AdSize.WIDE_SKYSCRAPER);
+    BANNER(AdmobModule.AD_SIZE_BANNER, AdSize.BANNER),
+    FLUID(AdmobModule.AD_SIZE_FLUID, AdSize.FLUID),
+    FULL_BANNER(AdmobModule.AD_SIZE_FULL_BANNER, AdSize.FULL_BANNER),
+    LARGE_BANNER(AdmobModule.AD_SIZE_LARGE_BANNER, AdSize.LARGE_BANNER),
+    LEADERBOARD(AdmobModule.AD_SIZE_LEADERBOARD, AdSize.LEADERBOARD),
+    MEDIUM_RECTANGLE(AdmobModule.AD_SIZE_MEDIUM_RECTANGLE, AdSize.MEDIUM_RECTANGLE),
+    SEARCH(AdmobModule.AD_SIZE_SEARCH, AdSize.SEARCH),
+    SMART_BANNER(AdmobModule.AD_SIZE_SMART_BANNER, AdSize.SMART_BANNER),
+    WIDE_SKYSCRAPER(AdmobModule.AD_SIZE_WIDE_SKYSCRAPER, AdSize.WIDE_SKYSCRAPER);
 
-	private final AdmobSizeProxy admobSizeProxy;
-	private final int adSizeConstantValue;
+    private final AdmobSizeProxy admobSizeProxy;
+    private final int adSizeConstantValue;
 
-	private AdmobSizeEnum(int intValue, AdSize adSizeValue)
-	{
-		this.admobSizeProxy = new AdmobSizeProxy(adSizeValue);
-		this.adSizeConstantValue = intValue;
-	}
+    AdmobSizeEnum(int intValue, AdSize adSizeValue) {
+        this.admobSizeProxy = new AdmobSizeProxy(adSizeValue);
+        this.adSizeConstantValue = intValue;
+    }
 
-	public static AdmobSizeEnum fromModuleConst(int value)
-	{
-		for (AdmobSizeEnum nextObject : AdmobSizeEnum.values()) {
-			if ((nextObject != null) && (nextObject.adSizeConstantValue == value)) {
-				return nextObject;
-			}
-		}
-		return null;
-	}
+    public static AdmobSizeEnum fromModuleConst(int value) {
+        for (AdmobSizeEnum nextObject : AdmobSizeEnum.values()) {
+            if ((nextObject != null) && (nextObject.adSizeConstantValue == value)) {
+                return nextObject;
+            }
+        }
+        return null;
+    }
 
-	public AdmobSizeProxy getAdmobSizeProxy()
-	{
-		return this.admobSizeProxy;
-	}
+    public AdmobSizeProxy getAdmobSizeProxy() {
+        return this.admobSizeProxy;
+    }
 }

--- a/android/src/ti/admob/AdmobSizeProxy.java
+++ b/android/src/ti/admob/AdmobSizeProxy.java
@@ -8,44 +8,38 @@
 package ti.admob;
 
 import com.google.android.gms.ads.AdSize;
+
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
-import org.appcelerator.kroll.common.Log;
 
 @Kroll.proxy
-public class AdmobSizeProxy extends KrollProxy
-{
+public class AdmobSizeProxy extends KrollProxy {
 
-	private AdSize adSize;
+    private static final String TAG = "AdmobSizeProxy";
+    private final AdSize adSize;
 
-	private static final String TAG = "AdmobSizeProxy";
+    public AdmobSizeProxy(AdSize adSizeValue) {
+        super();
+        this.adSize = adSizeValue;
+    }
 
-	public AdmobSizeProxy(AdSize adSizeValue)
-	{
-		super();
-		this.adSize = adSizeValue;
-	}
+    public AdSize getAdSize() {
+        return this.adSize;
+    }
 
-	public AdSize getAdSize()
-	{
-		return this.adSize;
-	}
+    @Kroll.method
+    public int getWidth() {
+        if (this.adSize != null) {
+            return adSize.getWidth();
+        }
+        return -1;
+    }
 
-	@Kroll.method
-	public int getWidth()
-	{
-		if (this.adSize != null) {
-			return adSize.getWidth();
-		}
-		return -1;
-	}
-
-	@Kroll.method
-	public int getHeight()
-	{
-		if (this.adSize != null) {
-			return adSize.getHeight();
-		}
-		return -1;
-	}
+    @Kroll.method
+    public int getHeight() {
+        if (this.adSize != null) {
+            return adSize.getHeight();
+        }
+        return -1;
+    }
 }

--- a/android/src/ti/admob/AdmobView.java
+++ b/android/src/ti/admob/AdmobView.java
@@ -7,219 +7,204 @@
  */
 package ti.admob;
 
+import android.annotation.SuppressLint;
 import android.os.Bundle;
-import com.google.ads.mediation.admob.AdMobAdapter;
-import com.google.android.gms.ads.AdListener;
+
 import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.AdView;
-import com.google.android.gms.ads.mediation.admob.AdMobExtras;
+
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.view.TiUIView;
 
-public class AdmobView extends TiUIView
-{
-	private static final String TAG = "AdMobView";
-	private AdView adView;
+public class AdmobView extends TiUIView {
+    private static final String TAG = "AdMobView";
+    AdmobSizeProxy prop_adSize = AdmobSizeEnum.BANNER.getAdmobSizeProxy();
+    String prop_adUnitId;
+    // Put these in extras bundle of load
+    Boolean prop_debugEnabled = false;
+    int prop_top;
+    int prop_left;
+    int prop_right;
+    String prop_color_bg;
+    String prop_color_bg_top;
+    String prop_color_border;
+    String prop_color_text;
+    String prop_color_link;
+    String prop_color_url;
+    // -------------------------------------
+    Bundle extras;
+    private AdView adView;
 
-	AdmobSizeProxy prop_adSize = AdmobSizeEnum.BANNER.getAdmobSizeProxy();
-	String prop_adUnitId;
-	// Put these in extras bundle of laod
-	Boolean prop_debugEnabled = false;
-	int prop_top;
-	int prop_left;
-	int prop_right;
-	String prop_color_bg;
-	String prop_color_bg_top;
-	String prop_color_border;
-	String prop_color_text;
-	String prop_color_link;
-	String prop_color_url;
-	// -------------------------------------
-	Bundle extras;
+    public AdmobView(final TiViewProxy proxy) {
+        super(proxy);
+    }
 
-	public AdmobView(final TiViewProxy proxy)
-	{
-		super(proxy);
-	}
+    private void createAdView() {
+        Log.d(TAG, "createAdView()");
 
-	private void createAdView()
-	{
-		Log.d(TAG, "createAdView()");
+        adView = new AdView(proxy.getActivity());
 
-		adView = new AdView(proxy.getActivity());
+        adView.setAdUnitId(prop_adUnitId);
+        adView.setAdSize(prop_adSize.getAdSize());
 
-		adView.setAdUnitId(prop_adUnitId);
-		adView.setAdSize(prop_adSize.getAdSize());
+        // set the listener
+        adView.setAdListener(new CommonAdListener(proxy, TAG));
+        adView.setPadding(prop_left, prop_top, prop_right, 0);
+        // Add the AdView to your view hierarchy.
+        // The view will have no size until the ad is loaded.
+        setNativeView(adView);
+        loadAd(prop_debugEnabled, null);
+    }
 
-		// set the listener
-		adView.setAdListener(new CommonAdListener(proxy, TAG));
-		adView.setPadding(prop_left, prop_top, prop_right, 0);
-		// Add the AdView to your view hierarchy.
-		// The view will have no size until the ad is loaded.
-		setNativeView(adView);
-		loadAd(prop_debugEnabled, null);
-	}
+    //Deprecated in 5.0.0. Should be remove in 6.0.0
+    private void loadAd(final Boolean testing, Bundle extrasBundle) {
+        proxy.getActivity().runOnUiThread(new Runnable() {
+            @SuppressLint("MissingPermission")
+            public void run() {
+                final AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
+                Log.d(TAG, "requestAd(Boolean testing) -- testing:" + testing);
+                if (testing) {
+                    // adRequestBuilder.addTestDevice(AdRequest.DEVICE_ID_EMULATOR);
+                }
+                Bundle bundle = createAdRequestProperties();
+                if (bundle.size() > 0) {
+                    Log.d(TAG, "extras.size() > 0 -- set ad properties");
+                    // adRequestBuilder.addNetworkExtras(new AdMobExtras(bundle));
+                }
+                adView.loadAd(adRequestBuilder.build());
+            }
+        });
+    }
 
-	//Deprecated in 5.0.0. Should be remove in 6.0.0
-	private void loadAd(final Boolean testing, Bundle extrasBundle)
-	{
-		proxy.getActivity().runOnUiThread(new Runnable() {
-			public void run()
-			{
-				final AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
-				Log.d(TAG, "requestAd(Boolean testing) -- testing:" + testing);
-				if (testing) {
-					adRequestBuilder.addTestDevice(AdRequest.DEVICE_ID_EMULATOR);
-				}
-				Bundle bundle = createAdRequestProperties();
-				if (bundle.size() > 0) {
-					Log.d(TAG, "extras.size() > 0 -- set ad properties");
-					adRequestBuilder.addNetworkExtras(new AdMobExtras(bundle));
-				}
-				adView.loadAd(adRequestBuilder.build());
-			}
-		});
-	}
+    public void nativeLoadAd(final KrollDict options) {
+        proxy.getActivity().runOnUiThread(new Runnable() {
+            @SuppressLint("MissingPermission")
+            public void run() {
+                final AdRequest.Builder adRequestBuilder = AdmobModule.createRequestBuilderWithOptions(options);
+                adView.loadAd(adRequestBuilder.build());
+            }
+        });
+    }
 
-	public void nativeLoadAd(final KrollDict options)
-	{
-		proxy.getActivity().runOnUiThread(new Runnable() {
-			public void run()
-			{
-				final AdRequest.Builder adRequestBuilder = AdmobModule.createRequestBuilderWithOptions(options);
-				adView.loadAd(adRequestBuilder.build());
-			}
-		});
-	}
+    @Override
+    public void processProperties(KrollDict d) {
+        super.processProperties(d);
+        if (d.containsKey(AdmobModule.PROPERTY_AD_UNIT_ID)) {
+            prop_adUnitId = d.getString(AdmobModule.PROPERTY_AD_UNIT_ID);
+        }
+        if (d.containsKey(AdmobModule.PROPERTY_AD_SIZE)) {
+            //KrollDict prop = d.getKrollDict(AdmobModule.PROPERTY_AD_SIZE);
+            prop_adSize = AdmobSizeEnum.fromModuleConst(d.getInt(AdmobModule.PROPERTY_AD_SIZE)).getAdmobSizeProxy();
+        }
+        if (d.containsKey(AdmobModule.PROPERTY_DEBUG_ENABLED)) {
+            warnForDeprecatedProperty(AdmobModule.PROPERTY_DEBUG_ENABLED);
+            prop_debugEnabled = d.getBoolean(AdmobModule.PROPERTY_DEBUG_ENABLED);
+        }
+        if (d.containsKey(AdmobModule.PROPERTY_COLOR_BG)) {
+            warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_BG);
+            Log.d(TAG, "has PROPERTY_COLOR_BG: " + d.getString(AdmobModule.PROPERTY_COLOR_BG));
+            prop_color_bg = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_BG));
+        }
+        if (d.containsKey(AdmobModule.PROPERTY_COLOR_BG_TOP)) {
+            warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_BG_TOP);
+            Log.d(TAG, "has PROPERTY_COLOR_BG_TOP: " + d.getString(AdmobModule.PROPERTY_COLOR_BG_TOP));
+            prop_color_bg_top = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_BG_TOP));
+        }
+        if (d.containsKey(AdmobModule.PROPERTY_COLOR_BORDER)) {
+            warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_BORDER);
+            Log.d(TAG, "has PROPERTY_COLOR_BORDER: " + d.getString(AdmobModule.PROPERTY_COLOR_BORDER));
+            prop_color_border = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_BORDER));
+        }
+        if (d.containsKey(AdmobModule.PROPERTY_COLOR_TEXT)) {
+            warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_TEXT);
+            Log.d(TAG, "has PROPERTY_COLOR_TEXT: " + d.getString(AdmobModule.PROPERTY_COLOR_TEXT));
+            prop_color_text = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_TEXT));
+        }
+        if (d.containsKey(AdmobModule.PROPERTY_COLOR_LINK)) {
+            warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_LINK);
+            Log.d(TAG, "has PROPERTY_COLOR_LINK: " + d.getString(AdmobModule.PROPERTY_COLOR_LINK));
+            prop_color_link = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_LINK));
+        }
+        if (d.containsKey(AdmobModule.PROPERTY_COLOR_URL)) {
+            warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_URL);
+            Log.d(TAG, "has PROPERTY_COLOR_URL: " + d.getString(AdmobModule.PROPERTY_COLOR_URL));
+            prop_color_url = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_URL));
+        }
 
-	@Override
-	public void processProperties(KrollDict d)
-	{
-		super.processProperties(d);
-		if (d.containsKey(AdmobModule.PROPERTY_AD_UNIT_ID)) {
-			prop_adUnitId = d.getString(AdmobModule.PROPERTY_AD_UNIT_ID);
-		}
-		if (d.containsKey(AdmobModule.PROPERTY_AD_SIZE)) {
-			//KrollDict prop = d.getKrollDict(AdmobModule.PROPERTY_AD_SIZE);
-			prop_adSize = AdmobSizeEnum.fromModuleConst(d.getInt(AdmobModule.PROPERTY_AD_SIZE)).getAdmobSizeProxy();
-		}
-		if (d.containsKey(AdmobModule.PROPERTY_DEBUG_ENABLED)) {
-			warnForDeprecatedProperty(AdmobModule.PROPERTY_DEBUG_ENABLED);
-			prop_debugEnabled = d.getBoolean(AdmobModule.PROPERTY_DEBUG_ENABLED);
-		}
-		if (d.containsKey(AdmobModule.PROPERTY_COLOR_BG)) {
-			warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_BG);
-			Log.d(TAG, "has PROPERTY_COLOR_BG: " + d.getString(AdmobModule.PROPERTY_COLOR_BG));
-			prop_color_bg = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_BG));
-		}
-		if (d.containsKey(AdmobModule.PROPERTY_COLOR_BG_TOP)) {
-			warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_BG_TOP);
-			Log.d(TAG, "has PROPERTY_COLOR_BG_TOP: " + d.getString(AdmobModule.PROPERTY_COLOR_BG_TOP));
-			prop_color_bg_top = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_BG_TOP));
-		}
-		if (d.containsKey(AdmobModule.PROPERTY_COLOR_BORDER)) {
-			warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_BORDER);
-			Log.d(TAG, "has PROPERTY_COLOR_BORDER: " + d.getString(AdmobModule.PROPERTY_COLOR_BORDER));
-			prop_color_border = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_BORDER));
-		}
-		if (d.containsKey(AdmobModule.PROPERTY_COLOR_TEXT)) {
-			warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_TEXT);
-			Log.d(TAG, "has PROPERTY_COLOR_TEXT: " + d.getString(AdmobModule.PROPERTY_COLOR_TEXT));
-			prop_color_text = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_TEXT));
-		}
-		if (d.containsKey(AdmobModule.PROPERTY_COLOR_LINK)) {
-			warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_LINK);
-			Log.d(TAG, "has PROPERTY_COLOR_LINK: " + d.getString(AdmobModule.PROPERTY_COLOR_LINK));
-			prop_color_link = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_LINK));
-		}
-		if (d.containsKey(AdmobModule.PROPERTY_COLOR_URL)) {
-			warnForDeprecatedProperty(AdmobModule.PROPERTY_COLOR_URL);
-			Log.d(TAG, "has PROPERTY_COLOR_URL: " + d.getString(AdmobModule.PROPERTY_COLOR_URL));
-			prop_color_url = AdmobModule.convertColorProp(d.getString(AdmobModule.PROPERTY_COLOR_URL));
-		}
+        // now create the adView
+        this.createAdView();
+    }
 
-		// now create the adView
-		this.createAdView();
-	}
+    private void warnForDeprecatedProperty(String property) {
+        Log.w(TAG, "You are using " + property
+                + " which is deprecated. Instead use the <extras> parameter in load() method.");
+    }
 
-	private void warnForDeprecatedProperty(String property)
-	{
-		Log.w(TAG, "You are using " + property
-					   + " which is deprecated. Instead use the <extras> parameter in load() method.");
-	}
+    public void pause() {
+        Log.d(TAG, "pause");
+        adView.pause();
+    }
 
-	public void pause()
-	{
-		Log.d(TAG, "pause");
-		adView.pause();
-	}
+    public void resume() {
+        Log.d(TAG, "resume");
+        adView.resume();
+    }
 
-	public void resume()
-	{
-		Log.d(TAG, "resume");
-		adView.resume();
-	}
+    public void destroy() {
+        Log.d(TAG, "destroy");
+        adView.destroy();
+    }
 
-	public void destroy()
-	{
-		Log.d(TAG, "destroy");
-		adView.destroy();
-	}
+    // pass the method the TESTING flag
+    // Deprecated in 5.0.0. Should be removed in 6.0.0
+    // Use nativeLoadAd() instead.
+    public void requestAd(KrollDict parameters) {
+        Log.d(TAG, "requestAd()");
 
-	// pass the method the TESTING flag
-	// Deprecated in 5.0.0. Should be removed in 6.0.0
-	// Use nativeLoadAd() instead.
-	public void requestAd(KrollDict parameters)
-	{
-		Log.d(TAG, "requestAd()");
+        if (parameters != null) {
+            // Pass additional extras if existing
+            if (parameters.containsKeyAndNotNull("extras")) {
+                extras = AdmobModule.mapToBundle(parameters.getKrollDict("extras"));
+            }
+        }
 
-		if (parameters != null) {
-			// Pass additional extras if existing
-			if (parameters.containsKeyAndNotNull("extras")) {
-				extras = AdmobModule.mapToBundle(parameters.getKrollDict("extras"));
-			}
-		}
+        loadAd(prop_debugEnabled, null);
+    }
 
-		loadAd(prop_debugEnabled, null);
-	}
+    // pass true to requestAd(Boolean testing) -- this overrides how the module was set
+    // Deprecated in 5.0.0. Should be removed in 6.0.0.
+    // Use the test parameter for nativeLoadAd() options instead.
+    public void requestTestAd() {
+        Log.d(TAG, "requestTestAd()");
+        loadAd(true, null);
+    }
 
-	// pass true to requestAd(Boolean testing) -- this overrides how the module was set
-	// Deprecated in 5.0.0. Should be removed in 6.0.0.
-	// Use the test parameter for nativeLoadAd() options instead.
-	public void requestTestAd()
-	{
-		Log.d(TAG, "requestTestAd()");
-		loadAd(true, null);
-	}
+    // helper methods
 
-	// helper methods
+    // http://code.google.com/mobile/ads/docs/bestpractices.html#adcolors
+    // Deprecated in 5.0.0. Should be removed in the next major version.
+    // Use createAdRequestExtrasBundleFromDictionary() instead.
+    private Bundle createAdRequestProperties() {
+        Bundle bundle = new Bundle();
+        if (prop_color_bg != null) {
+            Log.d(TAG, "color_bg: " + prop_color_bg);
+            bundle.putString("color_bg", prop_color_bg);
+        }
+        if (prop_color_bg_top != null)
+            bundle.putString("color_bg_top", prop_color_bg_top);
+        if (prop_color_border != null)
+            bundle.putString("color_border", prop_color_border);
+        if (prop_color_text != null)
+            bundle.putString("color_text", prop_color_text);
+        if (prop_color_link != null)
+            bundle.putString("color_link", prop_color_link);
+        if (prop_color_url != null)
+            bundle.putString("color_url", prop_color_url);
+        if (extras != null)
+            bundle.putAll(extras);
 
-	// http://code.google.com/mobile/ads/docs/bestpractices.html#adcolors
-	// Deprecated in 5.0.0. Should be removed in the next major version.
-	// Use createAdRequestExtrasBundleFromDictionary() instead.
-	private Bundle createAdRequestProperties()
-	{
-		Bundle bundle = new Bundle();
-		if (prop_color_bg != null) {
-			Log.d(TAG, "color_bg: " + prop_color_bg);
-			bundle.putString("color_bg", prop_color_bg);
-		}
-		if (prop_color_bg_top != null)
-			bundle.putString("color_bg_top", prop_color_bg_top);
-		if (prop_color_border != null)
-			bundle.putString("color_border", prop_color_border);
-		if (prop_color_text != null)
-			bundle.putString("color_text", prop_color_text);
-		if (prop_color_link != null)
-			bundle.putString("color_link", prop_color_link);
-		if (prop_color_url != null)
-			bundle.putString("color_url", prop_color_url);
-		if (extras != null)
-			bundle.putAll(extras);
-
-		return bundle;
-	}
+        return bundle;
+    }
 }

--- a/android/src/ti/admob/CommonAdListener.java
+++ b/android/src/ti/admob/CommonAdListener.java
@@ -7,75 +7,69 @@
 
 package ti.admob;
 
+import androidx.annotation.NonNull;
+
 import com.google.android.gms.ads.AdListener;
+import com.google.android.gms.ads.LoadAdError;
+
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.common.Log;
 
-public class CommonAdListener extends AdListener
-{
+public class CommonAdListener extends AdListener {
 
-	private final static String TAG = "AdEventListener";
+    private final static String TAG = "AdEventListener";
 
-	private KrollProxy sourceProxy;
-	private String sourceTag;
+    private final KrollProxy sourceProxy;
+    private final String sourceTag;
 
-	public CommonAdListener(KrollProxy sourceProxy, String tag)
-	{
-		this.sourceProxy = sourceProxy;
-		this.sourceTag = tag;
-	}
+    public CommonAdListener(KrollProxy sourceProxy, String tag) {
+        this.sourceProxy = sourceProxy;
+        this.sourceTag = tag;
+    }
 
-	@Override
-	public void onAdLoaded()
-	{
-		Log.d(this.sourceTag, "onAdLoaded()");
-		warnForDeprecatedConstant(AdmobModule.AD_RECEIVED, AdmobModule.EVENT_AD_LOAD);
-		this.sourceProxy.fireEvent(AdmobModule.AD_RECEIVED, new KrollDict());
-		this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_LOAD, new KrollDict());
-	}
+    @Override
+    public void onAdLoaded() {
+        Log.d(this.sourceTag, "onAdLoaded()");
+        warnForDeprecatedConstant(AdmobModule.AD_RECEIVED, AdmobModule.EVENT_AD_LOAD);
+        this.sourceProxy.fireEvent(AdmobModule.AD_RECEIVED, new KrollDict());
+        this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_LOAD, new KrollDict());
+    }
 
-	@Override
-	public void onAdFailedToLoad(int errorCode)
-	{
-		super.onAdFailedToLoad(errorCode);
-		Log.d(this.sourceTag, "onAdFailedToLoad(): " + errorCode);
-		KrollDict eventData = new KrollDict();
-		eventData.put("errorCode", String.valueOf(errorCode));
-		warnForDeprecatedConstant(AdmobModule.AD_NOT_RECEIVED, AdmobModule.EVENT_AD_FAIL);
-		this.sourceProxy.fireEvent(AdmobModule.AD_NOT_RECEIVED, eventData);
-		this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_FAIL, eventData);
-	}
+    @Override
+    public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
+        super.onAdFailedToLoad(loadAdError);
+        Log.d(this.sourceTag, "onAdFailedToLoad(): " + loadAdError);
+        KrollDict eventData = new KrollDict();
+        eventData.put("errorCode", loadAdError);
+        warnForDeprecatedConstant(AdmobModule.AD_NOT_RECEIVED, AdmobModule.EVENT_AD_FAIL);
+        this.sourceProxy.fireEvent(AdmobModule.AD_NOT_RECEIVED, eventData);
+        this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_FAIL, eventData);
+    }
 
-	@Override
-	public void onAdClosed()
-	{
-		super.onAdClosed();
-		warnForDeprecatedConstant(AdmobModule.AD_CLOSED, AdmobModule.EVENT_AD_CLOSED);
-		this.sourceProxy.fireEvent(AdmobModule.AD_CLOSED, new KrollDict());
-		this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_CLOSED, new KrollDict());
-	}
+    @Override
+    public void onAdClosed() {
+        super.onAdClosed();
+        warnForDeprecatedConstant(AdmobModule.AD_CLOSED, AdmobModule.EVENT_AD_CLOSED);
+        this.sourceProxy.fireEvent(AdmobModule.AD_CLOSED, new KrollDict());
+        this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_CLOSED, new KrollDict());
+    }
 
-	@Override
-	public void onAdOpened()
-	{
-		super.onAdOpened();
-		warnForDeprecatedConstant(AdmobModule.AD_OPENED, AdmobModule.EVENT_AD_OPENED);
-		this.sourceProxy.fireEvent(AdmobModule.AD_OPENED, new KrollDict());
-		this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_OPENED, new KrollDict());
-	}
+    @Override
+    public void onAdOpened() {
+        super.onAdOpened();
+        warnForDeprecatedConstant(AdmobModule.AD_OPENED, AdmobModule.EVENT_AD_OPENED);
+        this.sourceProxy.fireEvent(AdmobModule.AD_OPENED, new KrollDict());
+        this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_OPENED, new KrollDict());
+    }
 
-	@Override
-	public void onAdLeftApplication()
-	{
-		super.onAdLeftApplication();
-		warnForDeprecatedConstant(AdmobModule.AD_LEFT_APPLICATION, AdmobModule.EVENT_AD_LEFT_APP);
-		this.sourceProxy.fireEvent(AdmobModule.AD_LEFT_APPLICATION, new KrollDict());
-		this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_LEFT_APP, new KrollDict());
-	}
+    @Override
+    public void onAdClicked() {
+        super.onAdClicked();
+        this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_LEFT_APP, new KrollDict());
+    }
 
-	private void warnForDeprecatedConstant(String deprecatedConstant, String newConstant)
-	{
-		Log.w(TAG, "\"" + deprecatedConstant + "\" is deprecated. Use \"" + newConstant + "\" instead.");
-	}
+    private void warnForDeprecatedConstant(String deprecatedConstant, String newConstant) {
+        Log.w(TAG, "\"" + deprecatedConstant + "\" is deprecated. Use \"" + newConstant + "\" instead.");
+    }
 }

--- a/android/src/ti/admob/InterstitialAdProxy.java
+++ b/android/src/ti/admob/InterstitialAdProxy.java
@@ -7,72 +7,88 @@
 
 package ti.admob;
 
-import android.os.Bundle;
-import com.google.ads.mediation.admob.AdMobAdapter;
+import androidx.annotation.NonNull;
+
 import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.InterstitialAd;
+import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.interstitial.InterstitialAd;
+import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
+
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
 
 @Kroll.proxy(creatableInModule = AdmobModule.class)
-public class InterstitialAdProxy extends KrollProxy
-{
+public class InterstitialAdProxy extends KrollProxy {
 
-	private final String TAG = "InterstitialAd";
-	private InterstitialAd interstitialAd;
+    private final String TAG = "InterstitialAd";
+    String adId = "";
+    private InterstitialAd mInterstitialAd;
 
-	public InterstitialAdProxy()
-	{
-		this.interstitialAd = new InterstitialAd(getActivity());
-		this.interstitialAd.setAdListener(new CommonAdListener(this, TAG));
-	}
+    public InterstitialAdProxy() {
+        //this.interstitialAd = new InterstitialAd(getActivity());
+        //this.interstitialAd.setAdListener(new CommonAdListener(this, TAG));
+    }
 
-	@Override
-	public void handleCreationDict(KrollDict dict)
-	{
-		super.handleCreationDict(dict);
-		if (dict.containsKeyAndNotNull(AdmobModule.PROPERTY_AD_UNIT_ID)) {
-			this.interstitialAd.setAdUnitId(dict.getString(AdmobModule.PROPERTY_AD_UNIT_ID));
-		}
-	}
+    @Override
+    public void handleCreationDict(KrollDict dict) {
+        super.handleCreationDict(dict);
+        if (dict.containsKeyAndNotNull(AdmobModule.PROPERTY_AD_UNIT_ID)) {
+            //this.interstitialAd.setAdUnitId(dict.getString(AdmobModule.PROPERTY_AD_UNIT_ID));
+            adId = dict.getString(AdmobModule.PROPERTY_AD_UNIT_ID);
+        }
+    }
 
-	// clang format off
-	@Kroll.method
-	@Kroll.setProperty
-	public void setAdUnitId(String adUnitId)
-	// clang format on
-	{
-		// Validate the parameter
-		if (adUnitId != null && adUnitId instanceof String) {
-			this.interstitialAd.setAdUnitId(adUnitId);
-		}
-	}
+    // clang format off
+    @Kroll.method
+    @Kroll.getProperty
+    public String getAdUnitId()
+    // clang format on
+    {
+        return mInterstitialAd.getAdUnitId();
+    }
 
-	// clang format off
-	@Kroll.method
-	@Kroll.getProperty
-	public String getAdUnitId()
-	// clang format on
-	{
-		return this.interstitialAd.getAdUnitId();
-	}
+    // clang format off
+    @Kroll.method
+    @Kroll.setProperty
+    public void setAdUnitId(String adUnitId)
+    // clang format on
+    {
+        // Validate the parameter
+        if (adUnitId != null && adUnitId instanceof String) {
+            //
+        }
+    }
 
-	@Kroll.method
-	public void load(@Kroll.argument(optional = true) KrollDict options)
-	{
-		AdRequest.Builder adRequestBuilder = AdmobModule.createRequestBuilderWithOptions(options);
-		interstitialAd.loadAd(adRequestBuilder.build());
-	}
+    @Kroll.method
+    public void load(@Kroll.argument(optional = true) KrollDict options) {
+        AdRequest.Builder adRequestBuilder = AdmobModule.createRequestBuilderWithOptions(options);
+        InterstitialAd.load(getActivity(), adId, adRequestBuilder.build(), new InterstitialAdLoadCallback() {
+            @Override
+            public void onAdLoaded(@NonNull InterstitialAd interstitialAd) {
+                super.onAdLoaded(interstitialAd);
+                mInterstitialAd = interstitialAd;
+                fireEvent(AdmobModule.EVENT_AD_LOAD, new KrollDict());
+            }
 
-	@Kroll.method
-	public void show()
-	{
-		if (this.interstitialAd.isLoaded()) {
-			this.interstitialAd.show();
-		} else {
-			Log.w(TAG, "Trying to show an ad that has not been loaded.");
-		}
-	}
+            @Override
+            public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
+                super.onAdFailedToLoad(loadAdError);
+                mInterstitialAd = null;
+                KrollDict eventData = new KrollDict();
+                eventData.put("errorCode", loadAdError);
+                fireEvent(AdmobModule.EVENT_AD_FAIL, eventData);
+            }
+        });
+    }
+
+    @Kroll.method
+    public void show() {
+        if (this.mInterstitialAd != null) {
+            this.mInterstitialAd.show(getActivity());
+        } else {
+            Log.w(TAG, "Trying to show an ad that has not been loaded.");
+        }
+    }
 }

--- a/android/src/ti/admob/NativeAdView.java
+++ b/android/src/ti/admob/NativeAdView.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2011 by Studio Classics. All Rights Reserved.
+ * Copyright (c) 2017-present by Axway Appcelerator. All Rights Reserved.
+ * Author: Brian Kurzius, Axway Appcelerator
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package ti.admob;
+
+import android.annotation.SuppressLint;
+import android.content.res.Resources;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.RatingBar;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.AppCompatButton;
+
+import com.google.android.gms.ads.AdLoader;
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.nativead.MediaView;
+import com.google.android.gms.ads.nativead.NativeAd;
+import com.google.android.gms.ads.nativead.NativeAdOptions;
+
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.titanium.TiDimension;
+import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.view.TiUIView;
+
+public class NativeAdView extends TiUIView {
+    private final String TAG = "NativeAdView";
+    AdLoader adLoader;
+    private com.google.android.gms.ads.nativead.NativeAdView adView;
+    private String prop_adUnitId;
+    private int imageWidth = -1;
+
+
+    public NativeAdView(final TiViewProxy proxy) {
+        super(proxy);
+    }
+
+    @SuppressLint("MissingPermission")
+    private void createAdView() {
+        if (proxy.getProperty("adUnitId") != null && !proxy.getProperty("adUnitId").toString().isEmpty()) {
+            prop_adUnitId = proxy.getProperty("adUnitId").toString();
+        }
+
+        if (proxy.getProperty("imageWidth") != null && TiConvert.toInt(proxy.getProperty("imageWidth")) != -1) {
+            imageWidth = (int) proxy.getProperty("imageWidth");
+            imageWidth = TiConvert.toTiDimension(TiConvert.toInt(imageWidth),
+                    TiDimension.TYPE_WIDTH).getAsPixels(nativeView);
+        }
+        String packageName = proxy.getActivity().getPackageName();
+        Resources resources = proxy.getActivity().getResources();
+
+        int resId_adview = resources.getIdentifier("layout", "layout", packageName);
+        int resId_icon = resources.getIdentifier("ad_app_icon", "id", packageName);
+        int resId_headline = resources.getIdentifier("ad_headline", "id", packageName);
+        int resId_mediaview = resources.getIdentifier("ad_mediaview", "id", packageName);
+        int resId_button = resources.getIdentifier("cta", "id", packageName);
+        int resId_rating = resources.getIdentifier("rating_bar", "id", packageName);
+
+        LayoutInflater inflater = LayoutInflater.from(proxy.getActivity());
+        adView = (com.google.android.gms.ads.nativead.NativeAdView) inflater.inflate(resId_adview, null);
+        ImageView img = adView.findViewById(resId_icon);
+        if (imageWidth != -1) {
+            ViewGroup.LayoutParams layoutParam = img.getLayoutParams();
+            layoutParam.width = imageWidth;
+            img.setLayoutParams(layoutParam);
+        }
+        TextView textview = adView.findViewById(resId_headline);
+        MediaView mediaView = null;
+        if (adView.findViewById(resId_mediaview) != null) {
+            mediaView = adView.findViewById(resId_mediaview);
+        }
+        AppCompatButton button = adView.findViewById(resId_button);
+        RatingBar ratingbar = adView.findViewById(resId_rating);
+
+        MediaView finalMediaView = mediaView;
+        adLoader = new AdLoader.Builder(proxy.getActivity(), prop_adUnitId).forNativeAd(new NativeAd.OnNativeAdLoadedListener() {
+            @Override
+            public void onNativeAdLoaded(@NonNull NativeAd nativeAd) {
+                fireEvent("loaded", new KrollDict());
+                adView.setNativeAd(nativeAd);
+                textview.setText(nativeAd.getHeadline());
+
+                if (nativeAd.getIcon() != null) {
+                    img.setImageDrawable(nativeAd.getIcon().getDrawable());
+                    adView.setImageView(img);
+                }
+                adView.setHeadlineView(textview);
+                adView.setCallToActionView(button);
+
+                if (nativeAd.getStarRating() != null) {
+                    adView.setStarRatingView(ratingbar);
+                    ratingbar.setRating(nativeAd.getStarRating().floatValue());
+                    ratingbar.setEnabled(false);
+                    ratingbar.setVisibility(View.VISIBLE);
+                } else {
+                    ratingbar.setVisibility(View.GONE);
+                }
+                button.setText(nativeAd.getCallToAction());
+                if (finalMediaView != null) {
+                    adView.setMediaView(finalMediaView);
+                    finalMediaView.setMediaContent(nativeAd.getMediaContent());
+                    finalMediaView.setImageScaleType(ImageView.ScaleType.CENTER_CROP);
+                }
+            }
+        }).withNativeAdOptions(new NativeAdOptions.Builder().build()).build();
+        setNativeView(adView);
+        loadAd();
+    }
+
+    @SuppressLint("MissingPermission")
+    public void loadAd() {
+        adLoader.loadAd(new AdRequest.Builder().build());
+    }
+
+    @Override
+    public void processProperties(KrollDict d) {
+        super.processProperties(d);
+        if (d.containsKey(AdmobModule.PROPERTY_AD_UNIT_ID)) {
+            prop_adUnitId = d.getString(AdmobModule.PROPERTY_AD_UNIT_ID);
+        }
+
+        // now create the adView
+        this.createAdView();
+    }
+}

--- a/android/src/ti/admob/NativeAdViewProxy.java
+++ b/android/src/ti/admob/NativeAdViewProxy.java
@@ -11,66 +11,59 @@ import android.app.Activity;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
-import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiLifecycle.OnLifecycleEvent;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.view.TiUIView;
 
 @Kroll.proxy(creatableInModule = AdmobModule.class)
-public class BannerViewProxy extends TiViewProxy implements OnLifecycleEvent {
+public class NativeAdViewProxy extends TiViewProxy implements OnLifecycleEvent {
     protected static final String TAG = "BannerViewProxy";
-    private AdmobView adMob;
+    private NativeAdView adMob;
+    private String prop_adUnitId;
+    private int imageWidth = -1;
 
-    public BannerViewProxy() {
+    public NativeAdViewProxy() {
         super();
     }
 
     @Override
-    protected KrollDict getLangConversionTable() {
-        KrollDict table = new KrollDict();
-        table.put("title", "titleid");
-        return table;
-    }
-
-    @Override
     public TiUIView createView(Activity activity) {
-        adMob = new AdmobView(this);
+        adMob = new NativeAdView(this);
         ((TiBaseActivity) activity).addOnLifecycleEventListener(this);
         return adMob;
     }
 
-    @Kroll.method
-    public void requestAd(@Kroll.argument(optional = true) KrollDict parameters) {
-        adMob.requestAd(parameters);
-        Log.w(TAG, "requestAd() has been deprecated. Use load() instead.");
+    @Override
+    public void handleCreationDict(KrollDict options) {
+        super.handleCreationDict(options);
+        if (options.containsKeyAndNotNull("adUnitId")) {
+            prop_adUnitId = options.getString("adUnitId");
+        }
+        if (options.containsKeyAndNotNull("imageWidth")) {
+            imageWidth = options.getInt("imageWidth");
+        }
+
     }
 
     @Kroll.method
-    public void requestTestAd() {
-        adMob.requestTestAd();
-        Log.w(TAG, "requestAd() has been deprecated. Use load() with 'debugIdentifiers' property instead.");
-    }
-
-    @Kroll.method
-    public void load(@Kroll.argument(optional = true) KrollDict options) {
-        // Load ad with options...
-        adMob.nativeLoadAd(options);
+    public void loadAd(){
+        adMob.loadAd();
     }
 
     @Override
     public void onDestroy(Activity activity) {
-        adMob.destroy();
+
     }
 
     @Override
     public void onPause(Activity activity) {
-        adMob.pause();
+
     }
 
     @Override
     public void onResume(Activity activity) {
-        adMob.resume();
+
     }
 
     @Override

--- a/android/src/ti/admob/ViewProxy.java
+++ b/android/src/ti/admob/ViewProxy.java
@@ -14,15 +14,13 @@ import org.appcelerator.kroll.common.Log;
  * This class is left for backwards compatibility until
  * the deprecated createView() method for BannerView ad
  * is removed from the module. Users should use createBannerView()
-*/
+ */
 @Kroll.proxy(creatableInModule = AdmobModule.class)
-public class ViewProxy extends BannerViewProxy
-{
+public class ViewProxy extends BannerViewProxy {
 
-	protected static final String TAG = "AdMobViewProxy";
+    protected static final String TAG = "AdMobViewProxy";
 
-	public ViewProxy()
-	{
-		Log.w(TAG, "ViewProxy has been deprecated. Use createBannerView instead.");
-	}
+    public ViewProxy() {
+        Log.w(TAG, "ViewProxy has been deprecated. Use createBannerView instead.");
+    }
 }


### PR DESCRIPTION
Simple NativeAd layout: image, title, rating (if available), CTA button, Ad icon + text (required)

![Screenshot_20230415-123412](https://user-images.githubusercontent.com/4334997/232217522-2c418780-b731-4908-9710-379271d1e9e9.png)


```xml
<NativeAdView ns="Admob" id="ad" imageWidth="100" height="120" adUnitId="ca-app-pub-3940256099942544/2247696110" onLoaded="onLoaded"/>
```

* createNativeAdView({ imageWidth, adUnitId}): imageWidth is the width of the image
* event: `loaded`

[ti.admob-android-6.0.0.zip](https://github.com/tidev/ti.admob/files/11239296/ti.admob-android-6.0.0.zip)

You can fully customize the layout in your app by overwriting `platform/android/res/layout/layout.xml` but keeping the same IDs.